### PR TITLE
Allow min/max interval of the index to be smaller than search precision

### DIFF
--- a/src/main/java/com/farao_community/farao/dichotomy/Index.java
+++ b/src/main/java/com/farao_community/farao/dichotomy/Index.java
@@ -33,9 +33,6 @@ public class Index<T extends StepResult> {
         if (minValue > maxValue) {
             throw new DichotomyException("Index creation impossible, minValue is supposed to be lower than maxValue.");
         }
-        if (precision > maxValue - minValue) {
-            throw new DichotomyException("Index creation impossible, precision is bigger than actual research interval.");
-        }
         this.minValue = minValue;
         this.maxValue = maxValue;
         this.precision = precision;
@@ -90,8 +87,9 @@ public class Index<T extends StepResult> {
         if (higherSecureStep != null && Math.abs(higherSecureStep.stepValue() - maxValue) < EPSILON) {
             return true;
         }
-        double minInterval = higherSecureStep != null ? higherSecureStep.stepValue() : minValue;
-        double maxInterval = lowerUnsecureStep != null ? lowerUnsecureStep.stepValue() : maxValue;
-        return Math.abs(minInterval - maxInterval) < precision;
+        if (lowerUnsecureStep == null || higherSecureStep == null) {
+            return false;
+        }
+        return Math.abs(higherSecureStep.stepValue() - lowerUnsecureStep.stepValue()) < precision;
     }
 }

--- a/src/main/java/com/farao_community/farao/dichotomy/Index.java
+++ b/src/main/java/com/farao_community/farao/dichotomy/Index.java
@@ -78,9 +78,6 @@ public class Index<T extends StepResult> {
     }
 
     boolean precisionReached() {
-        if (lowerUnsecureStep == null && higherSecureStep == null) {
-            return false;
-        }
         if (lowerUnsecureStep != null && Math.abs(lowerUnsecureStep.stepValue() - minValue) < EPSILON) {
             return true;
         }

--- a/src/test/java/com/farao_community/farao/dichotomy/IndexTest.java
+++ b/src/test/java/com/farao_community/farao/dichotomy/IndexTest.java
@@ -32,8 +32,10 @@ class IndexTest {
     }
 
     @Test
-    void checkIndexCreationFailsIfPrecisionIsLowerThanSearchInterval() {
-        Assertions.assertThrows(DichotomyException.class, () -> new Index<>(-100, -100, 300));
+    void checkIndexCreationSucceedsIfPrecisionIsLowerThanSearchInterval() {
+        Index<DefaultStepResult> index = new Index<>(0, 100, 300);
+        assertEquals(0, index.minValue(), EPSILON);
+        assertEquals(100, index.maxValue(), EPSILON);
+        assertEquals(300, index.precision(), EPSILON);
     }
-
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, having a search interval smaller than dichotomy precision is forbidden and blocked by dichotomy engine.


**What is the new behavior (if this is a feature change)?**
When search interval is smaller than dichotomy precision, dichotomy engine at least checks the limits of the interval (and stop early if min is unsecure or max is secure).


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No

