### PR TITLE
Fix dependencies in maven for logs

### DIFF
--- a/dichotomy-api/pom.xml
+++ b/dichotomy-api/pom.xml
@@ -14,12 +14,17 @@
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/network-dichotomy/pom.xml
+++ b/network-dichotomy/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 
@@ -84,6 +84,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     </developers>
 
     <properties>
+        <logback.classic.version>1.2.3</logback.classic.version>
         <mockito.core.version>3.5.10</mockito.core.version>
     </properties>
 
@@ -56,6 +57,11 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.classic.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix maven imports


**What is the current behavior?** *(You can also link to an open issue here)*
the slf4j-simple module is imported as compile dependency


**What is the new behavior (if this is a feature change)?**
We replace this compile dependency by slf4j-api and we add logback-classic as test dependency for the implementation
