### PR TITLE
Fix interruption by using runId and common stop exchange

### DIFF
--- a/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/InterruptionStrategy.java
+++ b/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/InterruptionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -10,5 +10,5 @@ package com.farao_community.farao.dichotomy.api;
  * @author Vincent Bochet {@literal <vincent.bochet at rte-france.com>}
  */
 public interface InterruptionStrategy {
-    boolean shouldTaskBeInterruptedSoftly(String taskId);
+    boolean shouldRunBeInterruptedSoftly(String runId);
 }

--- a/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/DichotomyEngineTest.java
+++ b/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/DichotomyEngineTest.java
@@ -344,7 +344,7 @@ class DichotomyEngineTest {
         final IndexStrategy indexStrategy = new StepsIndexStrategy(true, stepsSize);
         final NetworkValidator<Object> networkValidator = new NetworkValidatorMock(limit);
         final InterruptionStrategy interruptionStrategy = mock(InterruptionStrategy.class);
-        when(interruptionStrategy.shouldTaskBeInterruptedSoftly("id")).thenReturn(false);
+        when(interruptionStrategy.shouldRunBeInterruptedSoftly("id")).thenReturn(false);
         final DichotomyEngine<Object> engine = new DichotomyEngine<>(index, indexStrategy, interruptionStrategy, mock(NetworkShifter.class), networkValidator, "id");
 
         final DichotomyResult<Object> dichotomyResult = engine.run(initialNetwork);
@@ -374,7 +374,7 @@ class DichotomyEngineTest {
         final IndexStrategy indexStrategy = new StepsIndexStrategy(true, stepsSize);
         final NetworkValidator<Object> networkValidator = new NetworkValidatorMock(limit);
         final InterruptionStrategy interruptionStrategy = mock(InterruptionStrategy.class);
-        when(interruptionStrategy.shouldTaskBeInterruptedSoftly("id")).thenReturn(true);
+        when(interruptionStrategy.shouldRunBeInterruptedSoftly("id")).thenReturn(true);
         final DichotomyEngine<Object> engine = new DichotomyEngine<>(index, indexStrategy, interruptionStrategy, mock(NetworkShifter.class), networkValidator, "id");
 
         final DichotomyResult<Object> dichotomyResult = engine.run(initialNetwork);
@@ -396,7 +396,7 @@ class DichotomyEngineTest {
         final IndexStrategy indexStrategy = new StepsIndexStrategy(true, stepsSize);
         final NetworkValidator<Object> networkValidator = new NetworkValidatorMock(limit);
         final InterruptionStrategy interruptionStrategy = mock(InterruptionStrategy.class);
-        when(interruptionStrategy.shouldTaskBeInterruptedSoftly("id")).thenReturn(false).thenReturn(true);
+        when(interruptionStrategy.shouldRunBeInterruptedSoftly("id")).thenReturn(false).thenReturn(true);
         final DichotomyEngine<Object> engine = new DichotomyEngine<>(index, indexStrategy, interruptionStrategy, mock(NetworkShifter.class), networkValidator, "id");
 
         final DichotomyResult<Object> dichotomyResult = engine.run(initialNetwork);
@@ -418,7 +418,7 @@ class DichotomyEngineTest {
         final NetworkValidator<Object> networkValidator = mock(NetworkValidator.class);
         when(networkValidator.validateNetwork(any(), any())).thenThrow(new RaoInterruptionException("test"));
         final InterruptionStrategy interruptionStrategy = mock(InterruptionStrategy.class);
-        when(interruptionStrategy.shouldTaskBeInterruptedSoftly("id")).thenReturn(false).thenReturn(true);
+        when(interruptionStrategy.shouldRunBeInterruptedSoftly("id")).thenReturn(false).thenReturn(true);
         final DichotomyEngine<Object> engine = new DichotomyEngine<>(index, indexStrategy, interruptionStrategy, mock(NetworkShifter.class), networkValidator, "id");
 
         final DichotomyResult<Object> dichotomyResult = engine.run(initialNetwork);
@@ -441,7 +441,7 @@ class DichotomyEngineTest {
         final NetworkValidator<Object> networkValidator = mock(NetworkValidator.class);
         when(networkValidator.validateNetwork(any(), any())).thenThrow(new RaoFailureException(failureMessage));
         final InterruptionStrategy interruptionStrategy = mock(InterruptionStrategy.class);
-        when(interruptionStrategy.shouldTaskBeInterruptedSoftly("id")).thenReturn(false);
+        when(interruptionStrategy.shouldRunBeInterruptedSoftly("id")).thenReturn(false);
         final DichotomyEngine<Object> engine = new DichotomyEngine<>(index, indexStrategy, interruptionStrategy, mock(NetworkShifter.class), networkValidator, "id");
 
         final DichotomyResult<Object> dichotomyResult = engine.run(initialNetwork);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced clarity by updating naming conventions and restructuring the interruption handling logic.
- **Tests**
  - Adjusted test configurations to align with the updated naming conventions.
- **Documentation**
  - Refreshed header information with an updated copyright year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->