### PR TITLE
Start dichotomy from midpoint for SWE processes

### DIFF
--- a/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategy.java
+++ b/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategy.java
@@ -6,12 +6,15 @@
  */
 package com.farao_community.farao.dichotomy.api.index;
 
+import com.farao_community.farao.dichotomy.api.results.DichotomyStepResult;
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * Implementation of IndexStrategy that consists of a basic dichotomy between minimum index value and maximum one.
  * First, it will validate minimum or maximum value (depending on startWitnMin value) and then validate recursively
  * the middle of the dichotomy interval.
  * I.E. if startWithMin is true then we start with min value then (min + max) / 2 value
- * if startWithMin is false then we start with max value then (min + max) / 2 value
+ * if startWithMin is false then we start with (min + max) / 2 value
  *
  * @author Marc Schwitzguebel {@literal <marc.schwitzguebel at rte-france.com>}
  */
@@ -28,22 +31,34 @@ public class HalfRangeDivisionIndexStrategy<T> implements IndexStrategy<T> {
         if (precisionReached(index)) {
             throw new AssertionError("Dichotomy engine should not ask for next value if precision is reached");
         }
+        final double maxValue = index.maxValue();
+        final double minValue = index.minValue();
+        final Pair<Double, DichotomyStepResult<T>> highestValidStep = index.highestValidStep();
+        final Pair<Double, DichotomyStepResult<T>> lowestValidStep = index.lowestInvalidStep();
         if (startWithMin) {
-            if (index.highestValidStep() == null) {
-                return index.minValue();
+            if (highestValidStep == null) {
+                return minValue;
             }
-            if (index.lowestInvalidStep() == null) {
-                return (index.maxValue() + index.highestValidStep().getLeft()) / 2;
+            if (lowestValidStep == null) {
+                return mid(highestValidStep.getLeft(), maxValue);
             }
         } else {
-            if (index.lowestInvalidStep() == null) {
-                return index.maxValue();
+            //coreso request for swe process: start the dichotomy with (max + min) /2
+            if (lowestValidStep == null && highestValidStep == null) {
+                return mid(minValue, maxValue);
             }
-            if (index.highestValidStep() == null) {
-                return (index.lowestInvalidStep().getLeft() + index.minValue()) / 2;
+            if (lowestValidStep == null && highestValidStep != null) {
+                return mid(highestValidStep.getLeft(), maxValue);
+            }
+            if (highestValidStep == null) {
+                return mid(minValue, lowestValidStep.getLeft());
             }
         }
         return index.meanOfStepVoltages();
+    }
+
+    private double mid(double min, double max) {
+        return (min + max) / 2.0;
     }
 
     @Override

--- a/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategy.java
+++ b/farao-dichotomy-api/src/main/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategy.java
@@ -34,24 +34,24 @@ public class HalfRangeDivisionIndexStrategy<T> implements IndexStrategy<T> {
         final double maxValue = index.maxValue();
         final double minValue = index.minValue();
         final Pair<Double, DichotomyStepResult<T>> highestValidStep = index.highestValidStep();
-        final Pair<Double, DichotomyStepResult<T>> lowestValidStep = index.lowestInvalidStep();
+        final Pair<Double, DichotomyStepResult<T>> lowestInvalidStep = index.lowestInvalidStep();
         if (startWithMin) {
             if (highestValidStep == null) {
                 return minValue;
             }
-            if (lowestValidStep == null) {
+            if (lowestInvalidStep == null) {
                 return mid(highestValidStep.getLeft(), maxValue);
             }
         } else {
             //coreso request for swe process: start the dichotomy with (max + min) /2
-            if (lowestValidStep == null && highestValidStep == null) {
+            if (lowestInvalidStep == null && highestValidStep == null) {
                 return mid(minValue, maxValue);
             }
-            if (lowestValidStep == null && highestValidStep != null) {
+            if (lowestInvalidStep == null) {
                 return mid(highestValidStep.getLeft(), maxValue);
             }
             if (highestValidStep == null) {
-                return mid(minValue, lowestValidStep.getLeft());
+                return mid(minValue, lowestInvalidStep.getLeft());
             }
         }
         return index.meanOfStepVoltages();

--- a/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
+++ b/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -24,6 +23,7 @@ class HalfRangeDivisionIndexStrategyTest {
 
     private static final double MIN_VALUE = 200.0;
     private static final double MAX_VALUE = 6400.0;
+    private static final double MID_VALUE = 3300.0;
     private static final double PRECISION = 50.0;
     private static final DichotomyStepResult<Boolean> STEP_RESULT_SUCCESS = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), null);
     private static final DichotomyStepResult<Boolean> STEP_RESULT_FAIL = DichotomyStepResult.fromFailure(ReasonInvalid.VALIDATION_FAILED, "test");
@@ -59,55 +59,34 @@ class HalfRangeDivisionIndexStrategyTest {
     }
 
     @Test
-    void nextValueStartWithMaxTest() {
+    void nextValueStartWithMidTest() {
         Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
         HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
-        assertEquals(MAX_VALUE, strategy.nextValue(index), PRECISION);
-        // if max is secure the process stops otherwise we have a highesInvalid
-        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
-        index.addDichotomyStepResult(MAX_VALUE, result);
-        assertEquals((MIN_VALUE + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
-        //we now have two options either valid or not: here we test valid
-        DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
-        index.addDichotomyStepResult((MIN_VALUE + MAX_VALUE) / 2, result2);
-        assertEquals(((MIN_VALUE + MAX_VALUE) / 2 + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
+        assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);
+        //here we test mid valid
+        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
+        index.addDichotomyStepResult(MID_VALUE, result);
+        assertEquals((MAX_VALUE + MID_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
-    void nextValueStartWithMaxTest2() {
+    void nextValueStartWithMidTest2() {
         Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
         HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
-        assertEquals(MAX_VALUE, strategy.nextValue(index), PRECISION);
-        // if  max is secure the process stops otherwise we have a highesInvalid
+        assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);
         DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
-        index.addDichotomyStepResult(MAX_VALUE, result);
-        assertEquals((MIN_VALUE + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
-        //we now have two options either valid or not: here we test invalid
-        DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
-        index.addDichotomyStepResult((MIN_VALUE + MAX_VALUE) / 2, result2);
-        assertEquals(((MIN_VALUE + MAX_VALUE) / 2 + MIN_VALUE) / 2, strategy.nextValue(index), PRECISION);
+        index.addDichotomyStepResult(MID_VALUE, result);
+        assertEquals((MIN_VALUE + MID_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
     void nextValuePrecisionReached() {
-        Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
+        Index<Boolean> index = new Index<>(0, 100, 50);
         HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
-        assertEquals(MAX_VALUE, strategy.nextValue(index), PRECISION);
-
-        index.addDichotomyStepResult(MAX_VALUE, STEP_RESULT_SUCCESS);
+        index.addDichotomyStepResult(50, STEP_RESULT_SUCCESS);
+        index.addDichotomyStepResult(90, STEP_RESULT_FAIL);
         assertTrue(strategy.precisionReached(index));
 
-        assertThrows(AssertionError.class, () -> strategy.nextValue(index));
-    }
-
-    @Test
-    void precisionReachedHighestStep() {
-        Index<Boolean> index = new Index<>(0, 160, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
-
-        double nextValue = strategy.nextValue(index); // 160
-        index.addDichotomyStepResult(nextValue, STEP_RESULT_SUCCESS);
-        assertTrue(strategy.precisionReached(index));
     }
 
     @Test
@@ -125,11 +104,7 @@ class HalfRangeDivisionIndexStrategyTest {
         Index<Boolean> index = new Index<>(0, 160, 50);
         HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
 
-        double nextValue = strategy.nextValue(index); // 160
-        index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
-        assertFalse(strategy.precisionReached(index));
-
-        nextValue = strategy.nextValue(index); // 80
+        double nextValue = strategy.nextValue(index); // 80
         index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
         assertFalse(strategy.precisionReached(index));
 
@@ -151,11 +126,7 @@ class HalfRangeDivisionIndexStrategyTest {
         Index<Boolean> index = new Index<>(0, 220, 50);
         HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
 
-        double nextValue = strategy.nextValue(index); // 220
-        index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
-        assertFalse(strategy.precisionReached(index));
-
-        nextValue = strategy.nextValue(index); // 110
+        double nextValue = strategy.nextValue(index); // 110
         index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
         assertFalse(strategy.precisionReached(index));
 

--- a/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
+++ b/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
@@ -59,7 +59,7 @@ class HalfRangeDivisionIndexStrategyTest {
     }
 
     @Test
-    void nextValueStartWithMidTest() {
+    void nextValueStartWithMidSecureStepResultTest() {
         final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
         final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
         assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);
@@ -70,7 +70,7 @@ class HalfRangeDivisionIndexStrategyTest {
     }
 
     @Test
-    void nextValueStartWithMidTest2() {
+    void nextValueStartWithMidInsecureStepResultTest() {
         final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
         final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
         assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);

--- a/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
+++ b/farao-dichotomy-api/src/test/java/com/farao_community/farao/dichotomy/api/index/HalfRangeDivisionIndexStrategyTest.java
@@ -30,59 +30,59 @@ class HalfRangeDivisionIndexStrategyTest {
 
     @Test
     void nextValueStartWithMinTest() {
-        Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(true);
+        final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(true);
         assertEquals(MIN_VALUE, strategy.nextValue(index), PRECISION);
         // if min is insecure the process stops otherwise we have a lowestValid
-        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
+        final DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
         index.addDichotomyStepResult(MIN_VALUE, result);
         assertEquals((MIN_VALUE + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
         //we now have two options either valid or not: here we test valid
-        DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
+        final DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
         index.addDichotomyStepResult((MIN_VALUE + MAX_VALUE) / 2, result2);
         assertEquals(((MIN_VALUE + MAX_VALUE) / 2 + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
     void nextValueStartWithMinTest2() {
-        Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(true);
+        final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(true);
         assertEquals(MIN_VALUE, strategy.nextValue(index), PRECISION);
         // if min is insecure the process stops otherwise we have a lowestValid
-        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
+        final DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
         index.addDichotomyStepResult(MIN_VALUE, result);
         assertEquals((MIN_VALUE + MAX_VALUE) / 2, strategy.nextValue(index), PRECISION);
         //we now have two options either valid or not: here we test invalid
-        DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
+        final DichotomyStepResult<Boolean> result2 = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
         index.addDichotomyStepResult((MIN_VALUE + MAX_VALUE) / 2, result2);
         assertEquals(((MIN_VALUE + MAX_VALUE) / 2 + MIN_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
     void nextValueStartWithMidTest() {
-        Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
         assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);
         //here we test mid valid
-        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
+        final DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(true), true);
         index.addDichotomyStepResult(MID_VALUE, result);
         assertEquals((MAX_VALUE + MID_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
     void nextValueStartWithMidTest2() {
-        Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(MIN_VALUE, MAX_VALUE, PRECISION);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
         assertEquals(MID_VALUE, strategy.nextValue(index), PRECISION);
-        DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
+        final DichotomyStepResult<Boolean> result = DichotomyStepResult.fromNetworkValidationResult(new RaoResultMock(false), false);
         index.addDichotomyStepResult(MID_VALUE, result);
         assertEquals((MIN_VALUE + MID_VALUE) / 2, strategy.nextValue(index), PRECISION);
     }
 
     @Test
     void nextValuePrecisionReached() {
-        Index<Boolean> index = new Index<>(0, 100, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(0, 100, 50);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
         index.addDichotomyStepResult(50, STEP_RESULT_SUCCESS);
         index.addDichotomyStepResult(90, STEP_RESULT_FAIL);
         assertTrue(strategy.precisionReached(index));
@@ -91,18 +91,18 @@ class HalfRangeDivisionIndexStrategyTest {
 
     @Test
     void precisionReachedLowestStep() {
-        Index<Boolean> index = new Index<>(0, 160, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(true);
+        final Index<Boolean> index = new Index<>(0, 160, 50);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(true);
 
-        double nextValue = strategy.nextValue(index); // 0
+        final double nextValue = strategy.nextValue(index); // 0
         index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
         assertTrue(strategy.precisionReached(index));
     }
 
     @Test
     void precisionReachedIfAllStepsAreUnsecure() {
-        Index<Boolean> index = new Index<>(0, 160, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(0, 160, 50);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
 
         double nextValue = strategy.nextValue(index); // 80
         index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);
@@ -115,16 +115,16 @@ class HalfRangeDivisionIndexStrategyTest {
 
     @Test
     void precisionReachedNoStepResult() {
-        Index<Boolean> index = new Index<>(0, 160, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(0, 160, 50);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
 
         assertFalse(strategy.precisionReached(index));
     }
 
     @Test
     void precisionReached() {
-        Index<Boolean> index = new Index<>(0, 220, 50);
-        HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy(false);
+        final Index<Boolean> index = new Index<>(0, 220, 50);
+        final HalfRangeDivisionIndexStrategy strategy = new HalfRangeDivisionIndexStrategy<>(false);
 
         double nextValue = strategy.nextValue(index); // 110
         index.addDichotomyStepResult(nextValue, STEP_RESULT_FAIL);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the half-range division search: first probe now starts from the midpoint in certain scenarios and frequently-used bounds are cached to reduce redundant calculations and improve stability.

* **Tests**
  * Updated and reworked test coverage to reflect the adjusted start behavior and refined precision-detection logic; added cases for no-results and revised precision sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->